### PR TITLE
Fix the bug that crashes the app when farm detail wants to be viewed

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -8,3 +8,4 @@
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
 # Add any project specific keep options here:
+-keep public class com.horcrux.svg.** {*;}


### PR DESCRIPTION
**What does this PR do?**
This PR fixes the bug that crashes the app when farm detail wants to be viewed. It appears that a rule had to be added in the proguard-rules